### PR TITLE
Signing and Verification with Cosign

### DIFF
--- a/.github/workflows/build_binary_nop_x86_64.yaml
+++ b/.github/workflows/build_binary_nop_x86_64.yaml
@@ -51,6 +51,12 @@ jobs:
         components: rustfmt, clippy
         target: x86_64-unknown-linux-gnu
 
+    - name: Update discordWebhookUrl in config/default.json
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      run: |
+        jq '.discordWebhookUrl = env.DISCORD_WEBHOOK' config/default.json > tmp.json && mv tmp.json config/default.json
+
     - name: Cache cargo registry and git dependencies
       uses: actions/cache@v3
       with:
@@ -117,6 +123,12 @@ jobs:
         override: true
         components: rustfmt, clippy
         target: x86_64-unknown-linux-gnu
+
+    - name: Update discordWebhookUrl in config/default.json
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      run: |
+        jq '.discordWebhookUrl = env.DISCORD_WEBHOOK' config/default.json > tmp.json && mv tmp.json config/default.json
 
     - name: Install Cosign
       run: |

--- a/.github/workflows/build_binary_nop_x86_64.yaml
+++ b/.github/workflows/build_binary_nop_x86_64.yaml
@@ -61,16 +61,34 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
+    - name: Install Cosign
+      run: |
+        curl -sSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+        chmod +x /usr/local/bin/cosign
+
     - name: Build binary
       run: |
         git submodule update --init --recursive
         RUSTFLAGS='-C link-arg=-s' cargo build --release --target x86_64-unknown-linux-gnu
+
+    - name: Sign the binary with Cosign
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+        COSIGN_EXPERIMENTAL: "true"
+      run: |
+        echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+        echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > airdao-nop-rs.pub
+
+        cosign sign-blob --key cosign.key --output-signature airdao-nop-rs.sig --yes target/x86_64-unknown-linux-gnu/release/airdao-nop-rs
 
     - name: Archive 
       run: |
         mkdir airdao-nop-rs
         cp target/x86_64-unknown-linux-gnu/release/airdao-nop-rs airdao-nop-rs/
         cp -r setup_templates/ config/ airdao-nop-rs/
+        cp airdao-nop-rs.sig  airdao-nop-rs.pub airdao-nop-rs/
         cp -r config/ airdao-nop-rs/
         cp update.sh airdao-nop-rs/
         zip -r airdao-nop-rs-x86-64.zip airdao-nop-rs/
@@ -100,26 +118,34 @@ jobs:
         components: rustfmt, clippy
         target: x86_64-unknown-linux-gnu
 
-    - name: Cache cargo registry and git dependencies
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    - name: Install Cosign
+      run: |
+        curl -sSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+        chmod +x /usr/local/bin/cosign
 
     - name: Build binary
       run: |
         git submodule update --init --recursive
         RUSTFLAGS='-C link-arg=-s' cargo build --release --target x86_64-unknown-linux-gnu
 
+    - name: Sign the binary with Cosign
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+        COSIGN_EXPERIMENTAL: "true"
+      run: |
+        echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+        echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > airdao-nop-rs.pub
+
+        cosign sign-blob --key cosign.key --output-signature airdao-nop-rs.sig --yes target/x86_64-unknown-linux-gnu/release/airdao-nop-rs
+
     - name: Archive 
       run: |
         mkdir airdao-nop-rs
         cp target/x86_64-unknown-linux-gnu/release/airdao-nop-rs airdao-nop-rs/
         cp -r setup_templates/ config/ airdao-nop-rs/
+        cp airdao-nop-rs.sig  airdao-nop-rs.pub airdao-nop-rs/
         cp -r config/ airdao-nop-rs/
         cp update.sh airdao-nop-rs/
         zip -r airdao-nop-rs-x86-64-old.zip airdao-nop-rs/

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,52 @@ apt-get install -y \
     jq \
     unzip
 
+# Install cosign 
+curl -sSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+chmod +x /usr/local/bin/cosign
+
+LATEST_TAG=$(curl -s https://raw.githubusercontent.com/ambrosus/airdao-nop-rs/main/Cargo.toml | grep '^version' | sed -E 's/version = "(.*)"/\1/')
+DISTRO_NAME=$(lsb_release -i | cut -d ':' -f 2 | xargs)
+MAJOR_VERSION=$(lsb_release -sr | cut -d '.' -f 1)
+
+echo "Distribution: $DISTRO_NAME"
+echo "Major version: $MAJOR_VERSION"
+
+if [[ "$DISTRO_NAME" == "Ubuntu" ]]; then
+    if (( MAJOR_VERSION >= 22 )); then
+        echo "Selecting new binary for Ubuntu"
+        FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64.zip"
+    else
+        echo "Selecting old binary for Ubuntu"
+        FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64-old.zip"
+    fi
+elif [[ "$DISTRO_NAME" == "Debian" ]]; then
+    if (( MAJOR_VERSION > 11 )); then
+        echo "Selecting new binary for Debian"
+        FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64.zip"
+    else
+        echo "Selecting old binary for Debian"
+        FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64-old.zip"
+    fi
+else
+    echo "Unknown distribution: $DISTRO_NAME"
+fi
+
+echo "Downloading from URL: $FILE_URL"
+
+curl -L -o airdao-nop-release.zip "$FILE_URL"
+unzip airdao-nop-release.zip
+rm airdao-nop-release.zip
+cd airdao-nop-rs || return
+
+if cosign verify-blob --key airdao-nop-rs.pub --signature airdao-nop-rs.sig airdao-nop-rs; then
+    echo -e "\033[0;32mVerified OK\033[0m"
+else
+    rm -rf ~/airdao-nop-rs 
+    echo -e "\033[0;31mError: Verification failed\033[0m"
+    exit 1
+fi
+
 if [ -f /etc/debian_version ]; then
     DISTRO=$(lsb_release -is)
     if [[ "$DISTRO" == "Debian" ]]; then
@@ -59,22 +105,6 @@ fi
 
 # Revert /etc/needrestart/needrestart.conf to original state after installing required packages
 sed -i 's/^\$nrconf{restart} = '\''a'\'';/$nrconf{restart} = '\''i'\'';/' /etc/needrestart/needrestart.conf
-
-LATEST_TAG=$(curl -s https://raw.githubusercontent.com/ambrosus/airdao-nop-rs/main/Cargo.toml | grep '^version' | sed -E 's/version = "(.*)"/\1/')
-UBUNTU_MAJOR_VERSION=$(lsb_release -sr | cut -d '.' -f 1)
-DEBIAN_MAJOR_VERSION=$(lsb_release -sr | cut -d '.' -f 1)
-
-if (( DEBIAN_MAJOR_VERSION > 11 )) || (( UBUNTU_MAJOR_VERSION >= 22 )); then
-    FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64.zip"
-else
-    FILE_URL="https://github.com/ambrosus/airdao-nop-rs/releases/download/v$LATEST_TAG/airdao-nop-rs-x86-64-old.zip"
-fi
-
-curl -L -o airdao-nop-release.zip "$FILE_URL"
-unzip airdao-nop-release.zip
-rm airdao-nop-release.zip
-
-cd airdao-nop-rs || return
 
 chmod +x update.sh
 ./update.sh


### PR DESCRIPTION

# Patch Notes for Artifact Signing with Cosign

### Objective
Set up artifact signing with Cosign and enable signature verification.

### Steps

1. **Generate Cosign Keys**  
   Generate a Cosign key pair to store in GitHub Secrets:
   ```bash
   cosign generate-key-pair github://[OWNER]/[PROJECT_NAME]
   ```
   This command will create `COSIGN_PRIVATE_KEY`, `COSIGN_PUBLIC_KEY`, and `COSIGN_PASSWORD` in the GitHub repository's secrets.

2. **Sign the Artifact**  
   Sign your binary file using the private key:
   ```bash
   cosign sign-blob --key cosign.key=(COSIGN_PRIVATE_KEY) --output-signature cosign.sig --yes <your_binary_file>
   ```

3. **Verify Signature**  
   Verify the artifact’s signature with the public key:
   ```bash
   cosign verify-blob --key airdao-nop-rs.pub=(COSIGN_PUBLIC_KEY) --signature cosign.sig <your_binary_file>
   ```

### Outcome
- Successfully signed and verified the artifact.
- Certificate and Rekor logs are available for future validation.

---
